### PR TITLE
Bifurcation code

### DIFF
--- a/CMlib/include/cm.h
+++ b/CMlib/include/cm.h
@@ -108,8 +108,9 @@ typedef void  (*CMthreadUserExecFunc)(size_t, size_t, void *);
 
 typedef struct CMthreadTask_s {
     size_t Id;
-    size_t Travel;
-    struct CMthreadTask_s *Dependent;
+    int Travel;
+    struct CMthreadTask_s *Dependents;
+    size_t NDependents;
 } CMthreadTask_t, *CMthreadTask_p;
 
 typedef struct CMthreadTaskGroup_s {
@@ -137,7 +138,7 @@ void CMthreadJobDestroy(CMthreadJob_p);
 
 CMreturn CMthreadJobExecute(CMthreadTeam_p, CMthreadJob_p);
 
-CMreturn CMthreadJobTaskDependent(CMthreadJob_p, size_t, size_t);
+CMreturn CMthreadJobTaskDependent(CMthreadJob_p, size_t, size_t *, int);
 
 #if defined(__cplusplus)
 }

--- a/CMlib/include/cm.h
+++ b/CMlib/include/cm.h
@@ -108,14 +108,13 @@ typedef void  (*CMthreadUserExecFunc)(size_t, size_t, void *);
 
 typedef struct CMthreadTask_s {
     size_t Id;
-    size_t Travel, Rank;
+    size_t Travel;
     struct CMthreadTask_s *Dependent;
 } CMthreadTask_t, *CMthreadTask_p;
 
 typedef struct CMthreadTaskGroup_s {
     size_t Start;
     size_t End;
-    size_t RankCount;
     size_t TravelCount;
 } CMthreadTaskGroup_t, *CMthreadTaskGroup_p;
 

--- a/CMlib/include/cm.h
+++ b/CMlib/include/cm.h
@@ -108,8 +108,9 @@ typedef void  (*CMthreadUserExecFunc)(size_t, size_t, void *);
 
 typedef struct CMthreadTask_s {
     size_t Id;
-    int Travel;
-    struct CMthreadTask_s *Dependents;
+    size_t Travel;
+    int isTravelSet;
+    struct CMthreadTask_s **Dependents;
     size_t NDependents;
 } CMthreadTask_t, *CMthreadTask_p;
 

--- a/CMlib/src/cmThreads.c
+++ b/CMlib/src/cmThreads.c
@@ -106,19 +106,13 @@ static int _CMthreadJobTaskCompare (const void *lPtr,const void *rPtr) {
 
 	if ((ret = (int) rTask->Travel - (int) lTask->Travel) != 0) return (ret);
 
-    // if first condition does not return, doesn't this always mean it returns on rtask==ltask,
-    // since they both walk downstream and end up null at the same time??
-    // SO sorting should be ok as long as travel length is computed for the LONGEST downstream
-    // direction. DEPENDENT pointer doesn't matter other than for computing TRAVEL, i think
-
     return 0;
 }
 
-// TODO TEST!
-size_t _travel_dist(CMthreadTask_t *task) {
+size_t _travel_dist(CMthreadTask_t *task) { // RECURSIVE
     int depi;
     size_t travel, maxtravel = 0;
-    if (task->isTravelSet) // been set already
+    if (task->isTravelSet) // been set already, quit early
         return task->Travel;
     if (task->Dependents != (CMthreadTask_p *) NULL) {
         for (depi = 0; depi < task->NDependents; depi++) {
@@ -139,17 +133,9 @@ CMreturn _CMthreadJobTaskSort (CMthreadJob_p job) {
 	CMthreadTask_p *dependent;
 
 	for (taskId = 0;taskId < job->TaskNum; ++taskId) {
-		/*travel = 0;*/
-        // this walks downstream along path computing travel (dist from node to mouth) and rank
-        // (max distance up to head)
-        // need to loop over all possible downstream paths, since can have multiple downstream
-        // dependents
-        /*for (dependent = job->Tasks + taskId; dependent->Dependents != (CMthreadTask_p) NULL; dependent = dependent->Dependent) {*/
-            /*travel += 1;*/
-		/*}*/
-        /*job->Tasks [taskId].Travel = travel;*/
-
-        // TODO TEST! correct?? who knows!
+        // walks downstream along path computing travel (dist from node to mouth)
+        // fills in travel dist for each node on path. start from each node to ensure
+        // visiting all nodes. skip if cell has already been reached
         if (job->Tasks[taskId].isTravelSet == 0) // unset
             job->Tasks[taskId].Travel = _travel_dist(job->Tasks + taskId);
 	}

--- a/MFlib/include/MF.h
+++ b/MFlib/include/MF.h
@@ -171,6 +171,7 @@ typedef struct MFDomain_s {
 MFDomain_t *MFDomainRead (FILE *);
 int  MFDomainWrite(MFDomain_t *, FILE *);
 int  MFDomainSetBifurcations(MFDomain_t *, const char *);
+#define MFBifurcationOpt "bifurcations"
 void MFDomainFree(MFDomain_t *);
 
 int  MFDateCompare (const char *, const char *);

--- a/MFlib/include/MF.h
+++ b/MFlib/include/MF.h
@@ -136,6 +136,7 @@ void   MFOptionPrintList();
 void   MFOptionMessage(const char *, const char *, const char *[]);
 
 
+int MFDomainSetBifurcations(MFDomain_t *, const char *);
 int MFModelRun(int, char *[], int, int (*)());
 int MFModelAddFunction(MFFunction);
 float MFModelGetXCoord(int);

--- a/MFlib/include/MF.h
+++ b/MFlib/include/MF.h
@@ -136,7 +136,6 @@ void   MFOptionPrintList();
 void   MFOptionMessage(const char *, const char *, const char *[]);
 
 
-int MFDomainSetBifurcations(MFDomain_t *, const char *);
 int MFModelRun(int, char *[], int, int (*)());
 int MFModelAddFunction(MFFunction);
 float MFModelGetXCoord(int);
@@ -171,6 +170,7 @@ typedef struct MFDomain_s {
 
 MFDomain_t *MFDomainRead (FILE *);
 int  MFDomainWrite(MFDomain_t *, FILE *);
+int  MFDomainSetBifurcations(MFDomain_t *, const char *);
 void MFDomainFree(MFDomain_t *);
 
 int  MFDateCompare (const char *, const char *);

--- a/MFlib/include/MF.h
+++ b/MFlib/include/MF.h
@@ -159,6 +159,7 @@ typedef struct MFObject_s {
     float XCoord, YCoord, Lon, Lat;
     float Area, Length;
     size_t *DLinks, *ULinks;
+    float *DWeights, *UWeights;
 } MFObject_t;
 
 typedef struct MFDomain_s {

--- a/MFlib/src/MFDomain.c
+++ b/MFlib/src/MFDomain.c
@@ -91,7 +91,7 @@ MFDomain_t *MFDomainRead (FILE *inFile) {
 				if (domain->Swap != 1)
 					for (i = 0;i < domain->Objects [objID].DLinkNum; ++i)
 						MFSwapWord (domain->Objects [objID].DLinks + i);
-                for (i = 0; i < domain->Objects [objID].DLinkNum; ++i)
+                for (i = 0; i < domain->Objects [objID].DLinkNum; ++i) {
                     if (i>1) CMmsgPrint(CMmsgSysError, "Bifurcation code assumption of single inital downlink WRONG at %s:%d",__FILE__,__LINE__);
                     // Set to equal weighting
                     /*domain->Objects[objID].DWeights[i] = 1./domain->Objects [objID].DLinkNum;*/
@@ -99,6 +99,7 @@ MFDomain_t *MFDomainRead (FILE *inFile) {
                     // correct, since otherwise all this code is wasted since the model already
                     // does it
                     domain->Objects[objID].DWeights[i] = 1.0;
+                }
 			}
 			else {
 				CMmsgPrint (CMmsgSysError,"File Reading Error in: %s:%d",__FILE__,__LINE__);

--- a/MFlib/src/MFDomain.c
+++ b/MFlib/src/MFDomain.c
@@ -92,12 +92,8 @@ MFDomain_t *MFDomainRead (FILE *inFile) {
 					for (i = 0;i < domain->Objects [objID].DLinkNum; ++i)
 						MFSwapWord (domain->Objects [objID].DLinks + i);
                 for (i = 0; i < domain->Objects [objID].DLinkNum; ++i) {
+                    // assume network originates with single downlink.
                     if (i>1) CMmsgPrint(CMmsgSysError, "Bifurcation code assumption of single inital downlink WRONG at %s:%d",__FILE__,__LINE__);
-                    // Set to equal weighting
-                    /*domain->Objects[objID].DWeights[i] = 1./domain->Objects [objID].DLinkNum;*/
-                    // Actually, just assume network originates with single downlink. Must be
-                    // correct, since otherwise all this code is wasted since the model already
-                    // does it
                     domain->Objects[objID].DWeights[i] = 1.0;
                 }
 			}
@@ -125,7 +121,7 @@ MFDomain_t *MFDomainRead (FILE *inFile) {
 					for (i = 0;i < domain->Objects [objID].ULinkNum; ++i)
 						MFSwapWord (domain->Objects [objID].ULinks + i);
                 for (i = 0; i < domain->Objects [objID].ULinkNum; ++i) {
-                    // Weights refer to weight of the link from UPSTREAM CELL perspective. So all the UWeights could be more or less than 1, but all the DWeights for a cell sum to 1.
+                    // Weights refer to fraction of UPSTREAM CELL outflow. So all the UWeights could be more or less than 1, but all the DWeights for a cell sum to 1.
                     // again, assuming single downlinks, so initial weight of each downlink is 1
                     domain->Objects[objID].UWeights[i] = 1.0;
                 }

--- a/MFlib/src/MFDomain.c
+++ b/MFlib/src/MFDomain.c
@@ -31,7 +31,7 @@ void MFDomainFree (MFDomain_t *domain) {
 }
 
 MFDomain_t *MFDomainRead (FILE *inFile) {
-	int objID, i, j, uItemID, ui;
+	int objID, i;
 	MFDomain_t *domain;
 
 	if ((domain = (MFDomain_t *) calloc (1,sizeof (MFDomain_t))) == (MFDomain_t *) NULL) return ((MFDomain_t *) NULL);

--- a/MFlib/src/MFModel.c
+++ b/MFlib/src/MFModel.c
@@ -491,7 +491,6 @@ int MFModelRun (int argc, char *argv [], int argNum, int (*mainDefFunc) ()) {
 	}
 	if ((_MFDomain = MFDomainRead (inFile)) == (MFDomain_t *) NULL)	return (CMfailed);
     if ((bifurFileName = MFOptionGet(MFBifurcationOpt)) != (char *) NULL) {
-        CMmsgPrint(CMmsgDebug, "bifur file: %s", bifurFileName);
         if (MFDomainSetBifurcations(_MFDomain, bifurFileName) == CMfailed) return (CMfailed);
     }
 
@@ -578,9 +577,6 @@ int MFModelRun (int argc, char *argv [], int argNum, int (*mainDefFunc) ()) {
         return (CMfailed);
     }
     for (taskId = 0; taskId < _MFDomain->ObjNum; ++taskId) {
-        // loop here over all dlinks? but currently each task/node can have only one dependent.
-        // needs multiple.
-        // or send in pointer to DLinks, pointer to taskID
         dlinks  = _MFDomain->Objects[taskId].DLinkNum > 0 ? _MFDomain->Objects[taskId].DLinks : (size_t *) &taskId;
         CMthreadJobTaskDependent(job, taskId, dlinks, _MFDomain->Objects[taskId].DLinkNum);
     }

--- a/MFlib/src/MFModel.c
+++ b/MFlib/src/MFModel.c
@@ -155,6 +155,8 @@ static int _MFModelParse (int argc, char *argv [],int argNum, int (*mainDefFunc)
 				return (CMfailed);
 			}
 			argv [argPos][i] = '\0';
+            CMmsgPrint  (CMmsgDebug,"Input variable [%s]: %s at: %s:%d",argv [argPos],argv[argPos]+i+1,__FILE__,__LINE__);
+            CMmsgPrint (CMmsgDebug, "bifur test: [%d]", strcmp(argv[argPos], "bifurcations"));
             if (strcmp(argv[argPos], "bifurcations") == 0) {
                 *bifurFile = argv[argPos] + i + 1;
             } else {
@@ -191,6 +193,7 @@ static int _MFModelParse (int argc, char *argv [],int argNum, int (*mainDefFunc)
 				return (CMfailed);
 			}
 			argv [argPos][i] = '\0';
+            CMmsgPrint  (CMmsgDebug,"Output variable [%s]: %s at: %s:%d",argv [argPos],argv[argPos]+i+1,__FILE__,__LINE__);
 			stateVars = _MFModelVarEntryNew (stateVars, stateVarNum, argv [argPos],argv [argPos] + i + 1);
 			if (stateVars == (varEntry_t *) NULL) return (CMfailed); else stateVarNum++;
 			if ((argNum = CMargShiftLeft(argPos,argv,argNum)) <= argPos) break;

--- a/MFlib/src/MFModel.c
+++ b/MFlib/src/MFModel.c
@@ -155,14 +155,8 @@ static int _MFModelParse (int argc, char *argv [],int argNum, int (*mainDefFunc)
 				return (CMfailed);
 			}
 			argv [argPos][i] = '\0';
-            CMmsgPrint  (CMmsgDebug,"Input variable [%s]: %s at: %s:%d",argv [argPos],argv[argPos]+i+1,__FILE__,__LINE__);
-            CMmsgPrint (CMmsgDebug, "bifur test: [%d]", strcmp(argv[argPos], "bifurcations"));
-            if (strcmp(argv[argPos], "bifurcations") == 0) {
-                *bifurFile = argv[argPos] + i + 1;
-            } else {
-                inputVars = _MFModelVarEntryNew (inputVars, inputVarNum, argv [argPos],argv [argPos] + i + 1);
-                if (inputVars == (varEntry_t *) NULL) return (CMfailed); else inputVarNum++;
-            }
+            inputVars = _MFModelVarEntryNew (inputVars, inputVarNum, argv [argPos],argv [argPos] + i + 1);
+            if (inputVars == (varEntry_t *) NULL) return (CMfailed); else inputVarNum++;
             if ((argNum = CMargShiftLeft(argPos,argv,argNum)) <= argPos) break;
 			continue;
 		}
@@ -495,8 +489,10 @@ int MFModelRun (int argc, char *argv [], int argNum, int (*mainDefFunc) ()) {
 		return (CMfailed);
 	}
 	if ((_MFDomain = MFDomainRead (inFile)) == (MFDomain_t *) NULL)	return (CMfailed);
-    if (bifurFileName != (char *) NULL)
+    if ((bifurFileName = MFOptionGet(MFBifurcationOpt)) != (char *) NULL) {
+        CMmsgPrint(CMmsgDebug, "bifur file: %s", bifurFileName);
         if (MFDomainSetBifurcations(_MFDomain, bifurFileName) == CMfailed) return (CMfailed);
+    }
 
 	for (var = MFVarGetByID (varID = 1);var != (MFVariable_t *) NULL;var = MFVarGetByID (++varID)) {
 		var->ItemNum = _MFDomain->ObjNum;

--- a/MFlib/src/MFModel.c
+++ b/MFlib/src/MFModel.c
@@ -130,7 +130,7 @@ static void _MFModelVarPrintOut (const char *label) {
                         CMyesNoString (var->Set),CMyesNoString (var->Flux),CMyesNoString (var->Initial), CMyesNoString (var->OutputPath != (char *) NULL));
 }
 
-static int _MFModelParse (int argc, char *argv [],int argNum, int (*mainDefFunc) (), char **domainFile, char **bifurFile, char **startDate, char **endDate, bool *testOnly) {
+static int _MFModelParse (int argc, char *argv [],int argNum, int (*mainDefFunc) (), char **domainFile, char **startDate, char **endDate, bool *testOnly) {
 	bool resolved = true;
 	int argPos, ret, help = false;
 	int i, varID;
@@ -441,7 +441,8 @@ int MFModelRun (int argc, char *argv [], int argNum, int (*mainDefFunc) ()) {
 	FILE *inFile;
 	int i, varID, ret = CMsucceeded, timeStep;
     size_t *dlinks, taskId;
-	char *startDate = (char *) NULL, *endDate = (char *) NULL, *domainFileName = (char *) NULL, *bifurFileName = (char *) NULL;
+	char *startDate = (char *) NULL, *endDate = (char *) NULL, *domainFileName = (char *) NULL;
+    const char *bifurFileName = (char *) NULL;
 	char dateCur [MFDateStringLength], dateNext [MFDateStringLength], *climatologyStr;
 	bool testOnly;
     void *buffer, *status;
@@ -473,7 +474,7 @@ int MFModelRun (int argc, char *argv [], int argNum, int (*mainDefFunc) ()) {
 		pthread_attr_setscope       (&thread_attr, PTHREAD_SCOPE_PROCESS);
 	}
 
-    if (_MFModelParse (argc,argv,argNum, mainDefFunc, &domainFileName, &bifurFileName, &startDate, &endDate, &testOnly) == CMfailed) return (CMfailed);
+    if (_MFModelParse (argc,argv,argNum, mainDefFunc, &domainFileName, &startDate, &endDate, &testOnly) == CMfailed) return (CMfailed);
  	if (testOnly) return (CMsucceeded);
 
     switch (strlen (startDate)) {

--- a/MFlib/src/MFModel.c
+++ b/MFlib/src/MFModel.c
@@ -442,7 +442,7 @@ enum { MFparIOnone, MFparIOsingle, MFparIOmulti };
 
 int MFModelRun (int argc, char *argv [], int argNum, int (*mainDefFunc) ()) {
 	FILE *inFile;
-	int i, varID, dlink, taskId, ret = CMsucceeded, timeStep;
+	int i, varID, *dlinks, taskId, ret = CMsucceeded, timeStep;
 	char *startDate = (char *) NULL, *endDate = (char *) NULL, *domainFileName = (char *) NULL, *bifurFileName = (char *) NULL;
 	char dateCur [MFDateStringLength], dateNext [MFDateStringLength], *climatologyStr;
 	bool testOnly;
@@ -577,8 +577,11 @@ int MFModelRun (int argc, char *argv [], int argNum, int (*mainDefFunc) ()) {
         return (CMfailed);
     }
     for (taskId = 0; taskId < _MFDomain->ObjNum; ++taskId) {
-        dlink  = _MFDomain->Objects[taskId].DLinkNum > 0 ? _MFDomain->Objects[taskId].DLinks[0] : taskId;
-        CMthreadJobTaskDependent(job, taskId, dlink);
+        // loop here over all dlinks? but currently each task/node can have only one dependent.
+        // needs multiple.
+        // or send in pointer to DLinks, pointer to taskID
+        dlinks  = _MFDomain->Objects[taskId].DLinkNum > 0 ? _MFDomain->Objects[taskId].DLinks : &taskId;
+        CMthreadJobTaskDependent(job, taskId, dlinks, _MFDomain->Objects[taskId].DLinkNum);
     }
     time(&sec);
     strcpy (dateCur,  MFDateGetCurrent ());

--- a/MFlib/src/MFModel.c
+++ b/MFlib/src/MFModel.c
@@ -442,7 +442,8 @@ enum { MFparIOnone, MFparIOsingle, MFparIOmulti };
 
 int MFModelRun (int argc, char *argv [], int argNum, int (*mainDefFunc) ()) {
 	FILE *inFile;
-	int i, varID, *dlinks, taskId, ret = CMsucceeded, timeStep;
+	int i, varID, taskId, ret = CMsucceeded, timeStep;
+    size_t *dlinks;
 	char *startDate = (char *) NULL, *endDate = (char *) NULL, *domainFileName = (char *) NULL, *bifurFileName = (char *) NULL;
 	char dateCur [MFDateStringLength], dateNext [MFDateStringLength], *climatologyStr;
 	bool testOnly;
@@ -580,7 +581,7 @@ int MFModelRun (int argc, char *argv [], int argNum, int (*mainDefFunc) ()) {
         // loop here over all dlinks? but currently each task/node can have only one dependent.
         // needs multiple.
         // or send in pointer to DLinks, pointer to taskID
-        dlinks  = _MFDomain->Objects[taskId].DLinkNum > 0 ? _MFDomain->Objects[taskId].DLinks : &taskId;
+        dlinks  = _MFDomain->Objects[taskId].DLinkNum > 0 ? _MFDomain->Objects[taskId].DLinks : (size_t *) &taskId;
         CMthreadJobTaskDependent(job, taskId, dlinks, _MFDomain->Objects[taskId].DLinkNum);
     }
     time(&sec);

--- a/MFlib/src/MFModel.c
+++ b/MFlib/src/MFModel.c
@@ -445,8 +445,8 @@ enum { MFparIOnone, MFparIOsingle, MFparIOmulti };
 
 int MFModelRun (int argc, char *argv [], int argNum, int (*mainDefFunc) ()) {
 	FILE *inFile;
-	int i, varID, taskId, ret = CMsucceeded, timeStep;
-    size_t *dlinks;
+	int i, varID, ret = CMsucceeded, timeStep;
+    size_t *dlinks, taskId;
 	char *startDate = (char *) NULL, *endDate = (char *) NULL, *domainFileName = (char *) NULL, *bifurFileName = (char *) NULL;
 	char dateCur [MFDateStringLength], dateNext [MFDateStringLength], *climatologyStr;
 	bool testOnly;

--- a/threadTest/src/threadTest.c
+++ b/threadTest/src/threadTest.c
@@ -10,6 +10,7 @@ static void _UserFunc(size_t threadId, size_t taskId, void *commonPtr) {
 int main(int argv, char *argc[]) {
     int ret, threadNum = 1;
     size_t loopNum = 4, timeLoop, taskNum = 10000, taskId;
+    size_t _taskId, _taskNum;
     CMthreadTeam_t team;
     CMthreadJob_p job;
 
@@ -28,8 +29,11 @@ int main(int argv, char *argc[]) {
         CMthreadTeamDestroy(&team);
         return (CMfailed);
     }
-    for (taskId = 0; taskId < taskNum; ++taskId)
-        CMthreadJobTaskDependent(job, taskId, (taskId | 0x0000000f) < taskNum ? (taskId | 0x0000000f) : taskNum - 1);
+    _taskNum = taskNum - 1;
+    for (taskId = 0; taskId < taskNum; ++taskId) {
+        _taskId = (taskId | 0x0000000f);
+        CMthreadJobTaskDependent(job, taskId, _taskId < taskNum ? &_taskId : &_taskNum, 1);
+    }
 
     for (timeLoop = 0; timeLoop < loopNum; ++timeLoop) {
         printf("Time %d\n", (int) timeLoop);


### PR DESCRIPTION
New code to read in a CSV file of river bifurcation locations, edit the river network in memory prior to running the model, and adjusting fluxes as the model runs to account for flux reductions when some is diverted. CSV file is a series of "fromID,toID,weight" lines, with ID's using 1-based indexing to match RGIS GUI IDs. Weight is a 0-1 decimal. CSV file name is provided as an option with name "bifurcations".  Also removed a bunch of code in the task sorting and comparison functions that seemed unused or unreachable, but probably worth taking a look to make sure I'm correct there. Also, the code assumes that all routed variables are extensive (like water volume). Any intensive variables (such as pollution concentrations) are computed within modules, correct?